### PR TITLE
Update References from master to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ When filing an issue, please check existing open, or recently closed, issues to 
 ## Contributing via Pull Requests
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *master* branch.
+1. You are working against the latest source on the *main* branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 


### PR DESCRIPTION
This PR was created to update all references from 'master' to 'main' in this repo.<br /><br />The following paths have been excluded: '[CHANGELOG.md .git/ go.mod go.sum]'<br /><br />**NOTE**: This PR was generated automatically. Please take a close look before approving and merging!